### PR TITLE
Fixed clipping and positioning

### DIFF
--- a/src/components/ClubsGrid.jsx
+++ b/src/components/ClubsGrid.jsx
@@ -53,7 +53,7 @@ function ClubsGrid() {
                                 role="button"
                                 tabIndex="0"
                             >
-                                Exit Pop
+                                Exit Pop &nbsp;
                                 <i className="fas fa-times" />
                             </div>
                             <div className="orgTitle">

--- a/src/components/Grid.css
+++ b/src/components/Grid.css
@@ -76,8 +76,8 @@ body {
 
 .exitPop {
   position: absolute;
-  left: 72.5%;
-  padding-top: 0.5rem;
+  left: 67.5%;
+  padding-top: 1.5rem;
   font-size: 1.5rem;
   color: white;
   transition: 0.5s;
@@ -89,10 +89,10 @@ body {
 }
 
 .popUpBackground {
-  position: absolute; /* Stay in place */
-  z-index: 1; /* Sit on top */
+  position: fixed; /* Stay in place */
+  z-index: 2; /* Sit on top */
   left: 0;
-  top: 0;
+  top: 2rem;
   width: 100%; /* Full width */
   height: 100%; /* Full height */
   /* Enable scroll if needed */


### PR DESCRIPTION
https://user-images.githubusercontent.com/30333942/110259981-60b1cc00-7f78-11eb-9078-0f727d794194.mp4

- Fixed pop-up clipping under Hero slogan (#12)
- Changed pop-up background positioning to "fixed" since the current overflow when scrolling to the bottom shows the main page
- Re-aligned some elements within pop-up body

Side thought:
The carousel background (transparent) isn't the same as the pop-up and changes to different clubs even though the current club description is different.